### PR TITLE
Update commands.md

### DIFF
--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -7,7 +7,7 @@ Commands can be defined in an EntityList or in a Dashboard. This documentation w
 ## Generator
 
 ```bash
-php artisan sharp:make:list-command <class_name> [--model=<model_name>]
+php artisan sharp:make:entity-command <class_name> [--model=<model_name>]
 ```
 
 ## Write the Command class


### PR DESCRIPTION
Just recognized that the command shown in the documentation doesn't exist (or maybe anymore).
As the guide uses the example of an entity list command I changed the page for that.
It changes "sharp:make:list-command" to "sharp:make:entity-command" as "list-command" doesn't exist in the current version (4.1.6).